### PR TITLE
Fix NS response encoding by explicity setting utf-8

### DIFF
--- a/ns_api.py
+++ b/ns_api.py
@@ -714,6 +714,7 @@ class NSAPI(object):
                              files=None,
                              auth=HTTPBasicAuth(self.username, self.apikey))
 
+        r.encoding = 'utf-8'
         r.raise_for_status()
         return r.text
 


### PR DESCRIPTION
If encoding is not set, encoding is determined as ISO-8859-1 (latin-1).
This results in wrong decoding of some station names, and possibly other characters.