### PR TITLE
Fix missing import and None time, issue #14

### DIFF
--- a/ns_api.py
+++ b/ns_api.py
@@ -9,7 +9,7 @@ from requests.auth import HTTPBasicAuth
 import xmltodict
 
 from utilkit import datetimeutil
-
+from datetime import datetime
 import time
 
 import json

--- a/ns_api.py
+++ b/ns_api.py
@@ -330,11 +330,12 @@ class TripStop(BaseObject):
         self.name = part_dict['Naam']
         try:
             self.time = datetimeutil.load_datetime(part_dict['Tijd'], NS_DATETIME)
+            self.key = datetimeutil.simple_time(self.time) + '_' + self.name
         except TypeError:
             # In some rare cases part_dict['Tijd'] can be None
             #self.time = datetime(2000, 1, 1, 0, 0, 0)
             self.time = None
-        self.key = datetimeutil.simple_time(self.time) + '_' + self.name
+            self.key = None
         self.platform_changed = False
         try:
             self.platform = part_dict['Spoor']['#text']


### PR DESCRIPTION
These are two fixes for https://github.com/aquatix/ns-api/issues/14 that I have encountered. 

The missing import is something that will be encountered regularly. 
The missing time is a rare exception.
I encounter both for nsmaps and have written a test for them here: https://github.com/bartromgens/nsmaps/blob/master/test.py#L29

Let me know if you prefer a different fix. These are simple local fixes.  

PS: I did all this on a train :)

