### PR TITLE
Raise custom exception on bad request

### DIFF
--- a/ns_api.py
+++ b/ns_api.py
@@ -171,6 +171,13 @@ def list_merge(list_a, list_b):
     return result
 
 
+# Exceptions
+
+class RequestParametersError(Exception):
+    """Exception raised when the request parameters were not accepted"""
+    pass
+
+
 # NS API objects
 class BaseObject:
     """
@@ -935,6 +942,9 @@ class NSAPI:
     def parse_stations(data):
         obj = json.loads(data)
         stations = []
+
+        if 'payload' not in obj:
+            raise RequestParametersError('The request could not be handled by the API')
 
         for station in obj['payload']:
             newstat = Station(station)


### PR DESCRIPTION
If a bad API key or station code is used, the NSAPI library will crash as it expects a trip as the response from NS. This PR allows NSAPI to recognize when NS was unable to process the request and will throw a custom exception.

@aquatix is invited to change the exception's name as he sees fit.