### PR TITLE
Removed references to "punctionality"

### DIFF
--- a/ns_api.py
+++ b/ns_api.py
@@ -446,7 +446,6 @@ class TripSubpart(BaseObject):
         # OVERSTAP-NIET-MOGELIJK, VERTRAAGD, NIEUW (=extra trein)
         self.going = True
         self.has_delay = False
-        self.punctuality = part_dict.get('punctionality', None)
         if part_dict['cancelled']:
             self.going = False
 
@@ -599,7 +598,6 @@ class Trip(BaseObject):
         except KeyError:
             # Fall back to the planned platform
             self.arrival_platform_actual = self.arrival_platform_planned
-        self.punctuality = trip_dict.get('punctionality', None)
 
         self.trip_parts = []
         raw_parts = trip_dict['legs']


### PR DESCRIPTION
This PR once again removes references to punctuality (or in this case, the typo "punctionality").

Brief history of punctuality and this repo:
Commit https://github.com/aquatix/ns-api/commit/4fa15fb70aa38803907fa74c788f92755f122edb: account for the eventuality of punctuality not being there in the response
Commit https://github.com/aquatix/ns-api/commit/d06ee1f94efba5eb78809199a8a5454906149a4b: permanent removal of punctuality references
Commit https://github.com/aquatix/ns-api/commit/3d82346de249b23a2505a8439aaf74d4b58dfba7: (accidental?) return of punctuality (more precisely, "punctionality") in a PR merge

Furthermore, after a few more tests, I can no longer find the punctuality in any API response any more. It seems NS has decided to let it go.

Given these arguments, I think we should also permanently remove punctuality from this library.

If this PR merges, we should close #24 