### PR TITLE
Raise custom exception when no JSON could be parsed

### DIFF
--- a/ns_api.py
+++ b/ns_api.py
@@ -874,6 +874,8 @@ class NSAPI:
         """Parse the NS API json result into Disruption objects.
 
         :param str data: raw json result from the NS API
+        :raises:
+            - NoDataReceivedError when the NS API did not return data
         """
         if not data:
             raise NoDataReceivedError('No disruptions were returned')
@@ -921,6 +923,8 @@ class NSAPI:
         """Parse the NS API json result into Departure objects.
 
         :param str data: raw json result from the NS API
+        :raises:
+            - NoDataReceivedError when the NS API did not return data
         """
         if not data:
             raise NoDataReceivedError('No departures were returned')
@@ -967,7 +971,15 @@ class NSAPI:
 
     @staticmethod
     def parse_trips(data, requested_time):
-        """Parse the NS API json result into Trip objects."""
+        """Parse the NS API json result into Trip objects.
+
+        :param str data: 'raw' response from API
+        :param datetime requested_time: Timestamp to look up the possibilities for
+        :return: list of the available trips
+        :rtype: list
+        :raises:
+            - NoDataReceivedError when the NS API did not return data
+        """
         if not data:
             raise NoDataReceivedError('No trips were returned')
         obj = json.loads(data)
@@ -1086,6 +1098,8 @@ class NSAPI:
         :param str data: 'raw' response from API
         :return: list of the stations
         :rtype: list
+        :raises:
+            - NoDataReceivedError when the NS API did not return data
         """
         if not data:
             raise NoDataReceivedError('No stations were returned')

--- a/ns_api.py
+++ b/ns_api.py
@@ -121,6 +121,9 @@ def list_from_json(source_list_json):
     if source_list_json == [] or source_list_json is None:
         return result
     for list_item in source_list_json:
+        if not list_item:
+            print('Item is None, skipping deserialisation')
+            continue
         item = json.loads(list_item)
         match item.get('class_name', None):
             case 'Departure':
@@ -205,6 +208,12 @@ def parse_enum(enum_class: Type[Enum], value) -> Enum | str | None:
 
 class RequestParametersError(Exception):
     """Exception raised when the request parameters were not accepted."""
+
+    pass
+
+
+class RequestFailedError(Exception):
+    """Exception raised when no valid response was returned from the API."""
 
     pass
 
@@ -866,6 +875,8 @@ class NSAPI:
 
         :param str data: raw json result from the NS API
         """
+        if not data:
+            raise RequestFailedError('No disruptions were returned')
         obj = json.loads(data)
         disruptions = {'unplanned': [], 'planned': []}
         if obj['payload']:
@@ -911,6 +922,8 @@ class NSAPI:
 
         :param str data: raw json result from the NS API
         """
+        if not data:
+            raise RequestFailedError('No departures were returned')
         obj = json.loads(data)
         departures = []
 
@@ -955,6 +968,8 @@ class NSAPI:
     @staticmethod
     def parse_trips(data, requested_time):
         """Parse the NS API xml result into Trip objects."""
+        if not data:
+            raise RequestFailedError('No trips were returned')
         obj = json.loads(data)
         trips = []
 
@@ -1072,6 +1087,8 @@ class NSAPI:
         :return: list of the stations
         :rtype: list
         """
+        if not data:
+            raise RequestFailedError('No stations were returned')
         obj = json.loads(data)
         stations = []
 

--- a/ns_api.py
+++ b/ns_api.py
@@ -967,7 +967,7 @@ class NSAPI:
 
     @staticmethod
     def parse_trips(data, requested_time):
-        """Parse the NS API xml result into Trip objects."""
+        """Parse the NS API json result into Trip objects."""
         if not data:
             raise NoDataReceivedError('No trips were returned')
         obj = json.loads(data)

--- a/ns_api.py
+++ b/ns_api.py
@@ -212,7 +212,7 @@ class RequestParametersError(Exception):
     pass
 
 
-class RequestFailedError(Exception):
+class NoDataReceivedError(Exception):
     """Exception raised when no valid response was returned from the API."""
 
     pass
@@ -876,7 +876,7 @@ class NSAPI:
         :param str data: raw json result from the NS API
         """
         if not data:
-            raise RequestFailedError('No disruptions were returned')
+            raise NoDataReceivedError('No disruptions were returned')
         obj = json.loads(data)
         disruptions = {'unplanned': [], 'planned': []}
         if obj['payload']:
@@ -923,7 +923,7 @@ class NSAPI:
         :param str data: raw json result from the NS API
         """
         if not data:
-            raise RequestFailedError('No departures were returned')
+            raise NoDataReceivedError('No departures were returned')
         obj = json.loads(data)
         departures = []
 
@@ -969,7 +969,7 @@ class NSAPI:
     def parse_trips(data, requested_time):
         """Parse the NS API xml result into Trip objects."""
         if not data:
-            raise RequestFailedError('No trips were returned')
+            raise NoDataReceivedError('No trips were returned')
         obj = json.loads(data)
         trips = []
 
@@ -1088,7 +1088,7 @@ class NSAPI:
         :rtype: list
         """
         if not data:
-            raise RequestFailedError('No stations were returned')
+            raise NoDataReceivedError('No stations were returned')
         obj = json.loads(data)
         stations = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,4 +61,4 @@ section-order = ["standard-library","third-party", "first-party", "testing", "lo
 testing = ["tests"]
 
 [tool.ruff.lint.mccabe]
-max-complexity = 10
+max-complexity = 11


### PR DESCRIPTION
This helps with #27. It still crashes by design, but now with a clear error on why.

The library could silently just return empty lists and such, but then you would not know that something is/went wrong.